### PR TITLE
Set AWS_REGION and AWS_DEFAULT_REGION earlier in the process

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -145,6 +145,9 @@ assume-role(){
     return
   fi
 
+  AWS_REGION="$region"
+  AWS_DEFAULT_REGION="$region"
+
   # Activate our session
   NOW=$(date +"%s")
   if [ -z "$AWS_SESSION_START" ]; then
@@ -220,8 +223,6 @@ assume-role(){
      # This will force a new session next time assume-role is run
      unset AWS_SESSION_START
   else
-    AWS_REGION="$region"
-    AWS_DEFAULT_REGION="$region"
     AWS_ACCESS_KEY_ID=$(echo "$ROLE_SESSION" | jq -r .Credentials.AccessKeyId)
     AWS_SECRET_ACCESS_KEY=$(echo "$ROLE_SESSION" | jq -r .Credentials.SecretAccessKey)
     AWS_SESSION_TOKEN=$(echo "$ROLE_SESSION" | jq -r .Credentials.SessionToken)


### PR DESCRIPTION
This PR sets AWS_REGION and AWS_DEFAULT_REGION earlier, to work around `aws` weirdness. See #11 for details.