### PR TITLE
JSON must be quoted to prevent leading zeroes from being dropped as int

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ You can define aliases to account ids in `~/.aws/accounts` which assume-role can
 
 ```json
 {
-  "default": 123456789012,
-  "staging": 123456789012,
-  "production": 123456789012
+  "default": "123456789012",
+  "staging": "123456789012",
+  "production": "123456789012"
 }
 ```
 


### PR DESCRIPTION
Small update, but I think will help.