### PR TITLE
Arbitrary names for the default profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Moreover, if you are in the need of [longer client-side assume-role sessions](ht
 $ export AWS_ROLE_SESSION_TIMEOUT=43200
 ```
 
+But be aware that for [chained roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining) there's currently a forced **1 hour limit** from AWS.
+
 ## AWS Bastion Account Setup
 
 Here is a simple example of how to set up a **Bastion** AWS account with an id `0987654321098` and a **Production** account with the id `123456789012`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ assume-role 123456789012 read
 ```
 
 Also, by setting `$AWS_DEFAULT_PROFILE_ASSUME_ROLE`, you can define a default profile for `assume-role` if you want to separate concerns between
-default accounts for `assume-role` and vanilla `awscli`:
+default accounts for `assume-role` and vanilla `awscli` or simply to have better names than `default`:
 
 ```bash
 $ export AWS_DEFAULT_PROFILE_ASSUME_ROLE="bastion"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ assume-role production read
 assume-role 123456789012 read
 ```
 
+Also, by setting `$AWS_DEFAULT_PROFILE_ASSUME_ROLE`, you can define a default profile for `assume-role` if you want to separate concerns between
+default accounts for `assume-role` and vanilla `awscli`:
+
+```bash
+$ export AWS_DEFAULT_PROFILE_ASSUME_ROLE="bastion"
+$ assume-role production read
+```
+
 ## AWS Bastion Account Setup
 
 Here is a simple example of how to set up a **Bastion** AWS account with an id `0987654321098` and a **Production** account with the id `123456789012`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ $ export AWS_DEFAULT_PROFILE_ASSUME_ROLE="bastion"
 $ assume-role production read
 ```
 
+Moreover, if you are in the need of [longer client-side assume-role sessions](https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/) and don't want to [enter your MFA authentication every hour (default)](https://github.com/coinbase/assume-role/issues/19) this one is for you:
+
+```bash
+$ export AWS_ROLE_SESSION_TIMEOUT=43200
+```
+
 ## AWS Bastion Account Setup
 
 Here is a simple example of how to set up a **Bastion** AWS account with an id `0987654321098` and a **Production** account with the id `123456789012`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Moreover, if you are in the need of [longer client-side assume-role sessions](ht
 $ export AWS_ROLE_SESSION_TIMEOUT=43200
 ```
 
-But be aware that for [chained roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining) there's currently a forced **1 hour limit** from AWS.
+However, be aware that for [chained roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining) there's currently a forced **1 hour limit** from AWS. You'll get the following error if you exceed that specific limit:
+
+> DurationSeconds exceeds the 1 hour session limit for roles assumed by role chaining.
 
 ## AWS Bastion Account Setup
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ assume-role production read
 assume-role 123456789012 read
 ```
 
-Also, by setting `$AWS_DEFAULT_PROFILE_ASSUME_ROLE`, you can define a default profile for `assume-role` if you want to separate concerns between
+Also, by setting `$AWS_PROFILE_ASSUME_ROLE`, you can define a default profile for `assume-role` if you want to separate concerns between
 default accounts for `assume-role` and vanilla `awscli` or simply to have better names than `default`:
 
 ```bash
-$ export AWS_DEFAULT_PROFILE_ASSUME_ROLE="bastion"
+$ export AWS_PROFILE_ASSUME_ROLE="bastion"
 $ assume-role production read
 ```
 

--- a/assume-role
+++ b/assume-role
@@ -131,7 +131,7 @@ assume-role(){
   fi
 
   # set region
-  AWS_CONFIG_REGION="$(aws configure get region)"
+  AWS_CONFIG_REGION="$(aws configure get region --profile ${default_profile})"
   if [ -z "$aws_region_input" ] && [ -z "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ] && [ -z "$AWS_CONFIG_REGION" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
     echo -n "Assume Into Region [us-east-1]: "
     read -r region
@@ -188,7 +188,8 @@ assume-role(){
     MFA_DEVICE_ARGS=(--user-name $AWS_USERNAME)
     MFA_DEVICE_ARGS+=(--query 'MFADevices[0].SerialNumber')
     MFA_DEVICE_ARGS+=(--output text)
-    MFA_DEVICE=$(aws iam list-mfa-devices "${MFA_DEVICE_ARGS[@]}" --profile $default_profile)
+    MFA_DEVICE_ARGS+=(--profile ${default_profile})
+    MFA_DEVICE=$(aws iam list-mfa-devices "${MFA_DEVICE_ARGS[@]}")
     MFA_DEVICE_STATUS=$?
 
     if [ $MFA_DEVICE_STATUS -ne 0 ]; then
@@ -228,7 +229,7 @@ assume-role(){
   ROLE_SESSION_ARGS+=(--external-id ${account_id})
   ROLE_SESSION_ARGS+=(--duration-seconds ${ROLE_SESSION_TIMEOUT})
   ROLE_SESSION_ARGS+=(--role-session-name $(date +%s))
-  ROLE_SESSION_ARGS+=(--profile ${default_profile})
+  
   ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
 
   if [ "$ROLE_SESSION" = "fail" ]; then

--- a/assume-role
+++ b/assume-role
@@ -47,6 +47,7 @@ assume-role(){
   #######
 
   # exports
+  export AWS_DEFAULT_PROFILE_ASSUME_ROLE
   export AWS_SESSION_START
   export AWS_SESSION_ACCESS_KEY_ID
   export AWS_SESSION_SECRET_ACCESS_KEY
@@ -80,6 +81,15 @@ assume-role(){
   #######
   # SETUP
   #######
+
+  # load default assume-role profile if available, use "default" otherwise
+  if [ -z "$AWS_DEFAULT_PROFILE_ASSUME_ROLE" ]; then
+    echo -n "Using default assume role (awscli) profile from environment variable"
+    default_profile=${AWS_DEFAULT_PROFILE_ASSUME_ROLE:-"default"}
+  fi
+
+  # XXX
+  default_profile="prod"
 
   # set account_name
   if [ -z "$account_name_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
@@ -173,13 +183,13 @@ assume-role(){
     fi
 
     # get the username attached to your default creds
-    AWS_USERNAME=$(aws iam get-user --query User.UserName --output text)
+    AWS_USERNAME=$(aws iam get-user --query User.UserName --output text --profile $default_profile)
 
     # get MFA device attached to default creds
     MFA_DEVICE_ARGS=(--user-name $AWS_USERNAME)
     MFA_DEVICE_ARGS+=(--query 'MFADevices[0].SerialNumber')
     MFA_DEVICE_ARGS+=(--output text)
-    MFA_DEVICE=$(aws iam list-mfa-devices "${MFA_DEVICE_ARGS[@]}")
+    MFA_DEVICE=$(aws iam list-mfa-devices "${MFA_DEVICE_ARGS[@]}" --profile $default_profile)
     MFA_DEVICE_STATUS=$?
 
     if [ $MFA_DEVICE_STATUS -ne 0 ]; then
@@ -191,7 +201,7 @@ assume-role(){
     SESSION_ARGS=(--duration-seconds $SESSION_TIMEOUT)
     SESSION_ARGS+=(--serial-number ${MFA_DEVICE})
     SESSION_ARGS+=(--token-code ${mfa_token})
-    SESSION=$(aws sts get-session-token "${SESSION_ARGS[@]}")
+    SESSION=$(aws sts get-session-token "${SESSION_ARGS[@]}" --profile $default_profile)
     SESSION_STATUS=$?
 
     if [ $SESSION_STATUS -ne 0 ]; then
@@ -216,7 +226,7 @@ assume-role(){
   ROLE_SESSION_ARGS+=(--external-id ${account_id})
   ROLE_SESSION_ARGS+=(--duration-seconds ${ROLE_SESSION_TIMEOUT})
   ROLE_SESSION_ARGS+=(--role-session-name $(date +%s))
-  ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
+  ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]} --profile $default_profile" || echo "fail")
 
   if [ "$ROLE_SESSION" = "fail" ]; then
      echo_out "Failed to export session envars."
@@ -235,6 +245,7 @@ assume-role(){
 
   # OUTPUTS ALL THE EXPORTS for eval $(assume-role [args])
   if [ "$OUTPUT_TO_EVAL" = "true" ]; then
+    echo "export AWS_DEFAULT_PROFILE_ASSUME_ROLE=\"$AWS_DEFAULT_PROFILE_ASSUME_ROLE\";"
     echo "export AWS_REGION=\"$AWS_REGION\";"
     echo "export AWS_DEFAULT_REGION=\"$AWS_DEFAULT_REGION\";"
     echo "export AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\";"

--- a/assume-role
+++ b/assume-role
@@ -47,7 +47,6 @@ assume-role(){
   #######
 
   # exports
-  export AWS_DEFAULT_PROFILE_ASSUME_ROLE
   export AWS_SESSION_START
   export AWS_SESSION_ACCESS_KEY_ID
   export AWS_SESSION_SECRET_ACCESS_KEY
@@ -61,6 +60,7 @@ assume-role(){
   export AWS_ACCOUNT_NAME
   export AWS_ACCOUNT_ROLE
   export GEO_ENV
+  export AWS_PROFILE_ASSUME_ROLE
 
   # INPUTS
   account_name_input=$1
@@ -83,9 +83,9 @@ assume-role(){
   #######
 
   # load default assume-role profile if available, use "default" otherwise
-  if [ "$AWS_DEFAULT_PROFILE_ASSUME_ROLE" ]; then
-    echo "Using assume-role default profile: $AWS_DEFAULT_PROFILE_ASSUME_ROLE"
-    default_profile=${AWS_DEFAULT_PROFILE_ASSUME_ROLE}
+  if [ "$AWS_PROFILE_ASSUME_ROLE" ]; then
+    echo "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
+    default_profile=${AWS_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"
   fi
@@ -190,10 +190,10 @@ assume-role(){
     AWS_USERNAME=$(aws iam get-user --query User.UserName --output text --profile $default_profile)
 
     # get MFA device attached to default creds
-    MFA_DEVICE_ARGS=(--user-name $AWS_USERNAME)
+    MFA_DEVICE_ARGS=(--user-name "$AWS_USERNAME")
     MFA_DEVICE_ARGS+=(--query 'MFADevices[0].SerialNumber')
     MFA_DEVICE_ARGS+=(--output text)
-    MFA_DEVICE_ARGS+=(--profile ${default_profile})
+    MFA_DEVICE_ARGS+=(--profile "${default_profile}")
     MFA_DEVICE=$(aws iam list-mfa-devices "${MFA_DEVICE_ARGS[@]}")
     MFA_DEVICE_STATUS=$?
 
@@ -203,10 +203,10 @@ assume-role(){
     fi
 
     # 12 hour MFA w/ Session Token, which can then be reused
-    SESSION_ARGS=(--duration-seconds $SESSION_TIMEOUT)
-    SESSION_ARGS+=(--serial-number ${MFA_DEVICE})
-    SESSION_ARGS+=(--token-code ${mfa_token})
-    SESSION_ARGS+=(--profile ${default_profile})
+    SESSION_ARGS=(--duration-seconds "$SESSION_TIMEOUT")
+    SESSION_ARGS+=(--serial-number "${MFA_DEVICE}")
+    SESSION_ARGS+=(--token-code "${mfa_token}")
+    SESSION_ARGS+=(--profile "${default_profile}")
 
     SESSION=$(aws sts get-session-token "${SESSION_ARGS[@]}")
 
@@ -230,10 +230,10 @@ assume-role(){
   export AWS_SESSION_TOKEN=$AWS_SESSION_SESSION_TOKEN
 
   # Now drop into a role using session token's long-lived MFA
-  ROLE_SESSION_ARGS=(--role-arn arn:aws:iam::${account_id}:role/${role})
-  ROLE_SESSION_ARGS+=(--external-id ${account_id})
-  ROLE_SESSION_ARGS+=(--duration-seconds ${ROLE_SESSION_TIMEOUT})
-  ROLE_SESSION_ARGS+=(--role-session-name $(date +%s))
+  ROLE_SESSION_ARGS=(--role-arn arn:aws:iam::"${account_id}":role/"${role}")
+  ROLE_SESSION_ARGS+=(--external-id "${account_id}")
+  ROLE_SESSION_ARGS+=(--duration-seconds "${ROLE_SESSION_TIMEOUT}")
+  ROLE_SESSION_ARGS+=(--role-session-name "$(date +%s)")
   
   ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
 
@@ -254,7 +254,6 @@ assume-role(){
 
   # OUTPUTS ALL THE EXPORTS for eval $(assume-role [args])
   if [ "$OUTPUT_TO_EVAL" = "true" ]; then
-    echo "export AWS_DEFAULT_PROFILE_ASSUME_ROLE=\"$AWS_DEFAULT_PROFILE_ASSUME_ROLE\";"
     echo "export AWS_REGION=\"$AWS_REGION\";"
     echo "export AWS_DEFAULT_REGION=\"$AWS_DEFAULT_REGION\";"
     echo "export AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\";"
@@ -268,11 +267,11 @@ assume-role(){
     echo "export AWS_SESSION_SESSION_TOKEN=\"$AWS_SESSION_SESSION_TOKEN\";"
     echo "export AWS_SESSION_START=\"$AWS_SESSION_START\";"
     echo "export GEO_ENV=\"$GEO_ENV\";"
+    echo "export AWS_PROFILE_ASSUME_ROLE=\"$AWS_PROFILE_ASSUME_ROLE\";"
   fi
 
   # USED FOR TESTING AND DEBUGGING
   if [ "$DEBUG_ASSUME_ROLE" = "true" ]; then
-    echo "AWS_DEFAULT_PROFILE_ASSUME_ROLE=\"$AWS_DEFAULT_PROFILE_ASSUME_ROLE\";"
     echo "AWS_CONFIG_REGION=\"$AWS_CONFIG_REGION\";"
     echo "AWS_USERNAME=\"$AWS_USERNAME\";"
     echo "MFA_DEVICE_ARGS=\"${MFA_DEVICE_ARGS[*]}\";"
@@ -283,6 +282,7 @@ assume-role(){
     echo "ROLE_SESSION=\"$ROLE_SESSION\";"
     echo "SESSION_TIMEOUT=\"$SESSION_TIMEOUT\";"
     echo "ROLE_SESSION_TIMEOUT=\"$ROLE_SESSION_TIMEOUT\";"
+    echo "AWS_PROFILE_ASSUME_ROLE=\"$AWS_PROFILE_ASSUME_ROLE\";"
   fi
 }
 

--- a/assume-role
+++ b/assume-role
@@ -71,7 +71,7 @@ assume-role(){
   # DEFAULT VARIABLES
   ACCOUNTS_FILE=${ACCOUNTS_FILE:-~/.aws/accounts}
   SESSION_TIMEOUT=43200
-  ROLE_SESSION_TIMEOUT=43200
+  ROLE_SESSION_TIMEOUT=3600
 
   # Force use of ~/.aws/credentials file which contains aws login account
   unset AWS_ACCESS_KEY_ID
@@ -88,6 +88,11 @@ assume-role(){
     default_profile=${AWS_DEFAULT_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"
+  fi
+
+  # load user-set ROLE_SESSION_TIMEOUT (up to 12h, 43200 seconds), use default 1h defined above otherwise
+  if [ "$AWS_ROLE_SESSION_TIMEOUT" ]; then
+    ROLE_SESSION_TIMEOUT=${AWS_ROLE_SESSION_TIMEOUT}
   fi
 
   # set account_name
@@ -273,9 +278,11 @@ assume-role(){
     echo "MFA_DEVICE_ARGS=\"${MFA_DEVICE_ARGS[*]}\";"
     echo "MFA_DEVICE=\"$MFA_DEVICE\";"
     echo "SESSION_ARGS=\"${SESSION_ARGS[*]}\";"
-    echo "SESSION='$SESSION';"
+    echo "SESSION=\"$SESSION\";"
     echo "ROLE_SESSION_ARGS=\"${ROLE_SESSION_ARGS[*]}\";"
-    echo "ROLE_SESSION='$ROLE_SESSION';"
+    echo "ROLE_SESSION=\"$ROLE_SESSION\";"
+    echo "SESSION_TIMEOUT=\"$SESSION_TIMEOUT\";"
+    echo "ROLE_SESSION_TIMEOUT=\"$ROLE_SESSION_TIMEOUT\";"
   fi
 }
 

--- a/assume-role
+++ b/assume-role
@@ -71,7 +71,7 @@ assume-role(){
   # DEFAULT VARIABLES
   ACCOUNTS_FILE=${ACCOUNTS_FILE:-~/.aws/accounts}
   SESSION_TIMEOUT=43200
-  ROLE_SESSION_TIMEOUT=3600
+  ROLE_SESSION_TIMEOUT=43200
 
   # Force use of ~/.aws/credentials file which contains aws login account
   unset AWS_ACCESS_KEY_ID

--- a/assume-role
+++ b/assume-role
@@ -83,13 +83,12 @@ assume-role(){
   #######
 
   # load default assume-role profile if available, use "default" otherwise
-  if [ -z "$AWS_DEFAULT_PROFILE_ASSUME_ROLE" ]; then
-    echo -n "Using default assume role (awscli) profile from environment variable"
-    default_profile=${AWS_DEFAULT_PROFILE_ASSUME_ROLE:-"default"}
+  if [ "$AWS_DEFAULT_PROFILE_ASSUME_ROLE" ]; then
+    echo "Using assume-role default profile: $AWS_DEFAULT_PROFILE_ASSUME_ROLE"
+    default_profile=${AWS_DEFAULT_PROFILE_ASSUME_ROLE}
+  else
+    default_profile="default"
   fi
-
-  # XXX
-  default_profile="prod"
 
   # set account_name
   if [ -z "$account_name_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
@@ -201,7 +200,10 @@ assume-role(){
     SESSION_ARGS=(--duration-seconds $SESSION_TIMEOUT)
     SESSION_ARGS+=(--serial-number ${MFA_DEVICE})
     SESSION_ARGS+=(--token-code ${mfa_token})
-    SESSION=$(aws sts get-session-token "${SESSION_ARGS[@]}" --profile $default_profile)
+    SESSION_ARGS+=(--profile ${default_profile})
+
+    SESSION=$(aws sts get-session-token "${SESSION_ARGS[@]}")
+
     SESSION_STATUS=$?
 
     if [ $SESSION_STATUS -ne 0 ]; then
@@ -226,7 +228,8 @@ assume-role(){
   ROLE_SESSION_ARGS+=(--external-id ${account_id})
   ROLE_SESSION_ARGS+=(--duration-seconds ${ROLE_SESSION_TIMEOUT})
   ROLE_SESSION_ARGS+=(--role-session-name $(date +%s))
-  ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]} --profile $default_profile" || echo "fail")
+  ROLE_SESSION_ARGS+=(--profile ${default_profile})
+  ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
 
   if [ "$ROLE_SESSION" = "fail" ]; then
      echo_out "Failed to export session envars."
@@ -263,6 +266,7 @@ assume-role(){
 
   # USED FOR TESTING AND DEBUGGING
   if [ "$DEBUG_ASSUME_ROLE" = "true" ]; then
+    echo "AWS_DEFAULT_PROFILE_ASSUME_ROLE=\"$AWS_DEFAULT_PROFILE_ASSUME_ROLE\";"
     echo "AWS_CONFIG_REGION=\"$AWS_CONFIG_REGION\";"
     echo "AWS_USERNAME=\"$AWS_USERNAME\";"
     echo "MFA_DEVICE_ARGS=\"${MFA_DEVICE_ARGS[*]}\";"

--- a/test/assume-role.bats
+++ b/test/assume-role.bats
@@ -75,14 +75,15 @@ teardown() {
   [ "${lines[9]}" = 'export AWS_SESSION_ACCESS_KEY_ID="session_key_id";' ]
   [ "${lines[10]}" = 'export AWS_SESSION_SECRET_ACCESS_KEY="session_secret_key";' ]
   [ "${lines[11]}" = 'export AWS_SESSION_SESSION_TOKEN="session_session_token";' ]
-  [ "${lines[14]}" = 'AWS_CONFIG_REGION="nz-north-1";' ]
-  [ "${lines[15]}" = 'AWS_USERNAME="aws_username";' ]
-  [[ "${lines[16]}" == *"--user-name aws_username"* ]] || false
-  [ "${lines[17]}" = 'MFA_DEVICE="arn:aws:iam::123456789012:mfa/BobsMFADevice";' ]
-  [[ "${lines[18]}" == *"--serial-number arn:aws:iam::123456789012:mfa/BobsMFADevice"* ]] || false
-  [[ "${lines[18]}" == *"--token-code 123456"* ]] || false
-  [[ "${lines[20]}" == *"--role-arn arn:aws:iam::123456789012:role/look_around"* ]] || false
-  [[ "${lines[20]}" == *"--external-id 123456789012"* ]] || false
+  [ "${lines[14]}" = 'export AWS_PROFILE_ASSUME_ROLE="";' ]
+  [ "${lines[15]}" = 'AWS_CONFIG_REGION="nz-north-1";' ]
+  [ "${lines[16]}" = 'AWS_USERNAME="aws_username";' ]
+  [[ "${lines[17]}" == *"--user-name aws_username"* ]] || false
+  [ "${lines[18]}" = 'MFA_DEVICE="arn:aws:iam::123456789012:mfa/BobsMFADevice";' ]
+  [[ "${lines[19]}" == *"--serial-number arn:aws:iam::123456789012:mfa/BobsMFADevice"* ]] || false
+  [[ "${lines[19]}" == *"--token-code 123456"* ]] || false
+  [[ "${lines[21]}" == *"--role-arn arn:aws:iam::123456789012:role/look_around"* ]] || false
+  [[ "${lines[21]}" == *"--external-id 123456789012"* ]] || false
 }
 
 @test "should fail if the account_id is bad" {


### PR DESCRIPTION
Hello Coinbase,

Here's a simple changeset that does not break backwards compatibility (`default` profile stays the same if env var is not defined).

This change just gives some flexibility for the assumption of the `default` profile naming.

Please let us know if you require further changes, we would like to have those changes upstream :)

/ping @reisingerf