### PR TITLE
fix echo for assume role default profile

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -87,7 +87,7 @@ assume-role(){
 
   # load default assume-role profile if available, use "default" otherwise
   if [ "$AWS_PROFILE_ASSUME_ROLE" ]; then
-    echo "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
+    echo_out "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
     default_profile=${AWS_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"


### PR DESCRIPTION
When running assume-role with eval +  setting $AWS_PROFILE_ASSUME_ROLE we get an error in bash. This should output the role properly.