### PR TITLE
fix error by using eval $(assume-role ...) together with AWS_PROFILE_ASSUME_ROLE set

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -87,7 +87,7 @@ assume-role(){
 
   # load default assume-role profile if available, use "default" otherwise
   if [ "$AWS_PROFILE_ASSUME_ROLE" ]; then
-    echo "# Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
+    echo "echo 'Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE';"
     default_profile=${AWS_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"

--- a/assume-role
+++ b/assume-role
@@ -87,7 +87,7 @@ assume-role(){
 
   # load default assume-role profile if available, use "default" otherwise
   if [ "$AWS_PROFILE_ASSUME_ROLE" ]; then
-    echo "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
+    echo "# Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
     default_profile=${AWS_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"


### PR DESCRIPTION
when you use the current assume-role like this

`eval $(AWS_PROFILE_ASSUME_ROLE=myprofile assume-role myaccount myrole)`

you get the error:

`-bash: Using: command not found`

you can fix this by adding echo '...'; to the string.