### PR TITLE
Fix bash prompt recommendation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ function aws_account_info {
   [ "$AWS_ACCOUNT_NAME" ] && [ "$AWS_ACCOUNT_ROLE" ] && echo -n "aws:($AWS_ACCOUNT_NAME:$AWS_ACCOUNT_ROLE) "
 }
 
-PROMPT_COMMAND='aws_account_info'
+# better handling if file is re-sourced
+if [ -z "$ORIG_PS1" ]; then
+   ORIG_PS1=$PS1
+fi
+PS1="\$(aws_account_info)$ORIG_PS1"
 ```
 
 ## Testing


### PR DESCRIPTION
Previous bash prompt recommendation used PROMPT_COMMAND to echo to the
screen. This messes up bash's ability to detect where you are in a line
if you re-run a command from your history. PROMPT_COMMAND should not
be used for this purpose per https://lists.gnu.org/archive/html/bug-bash/2015-04/msg00176.html

Changed to follow recommendations for Prompt_customization from
https://wiki.archlinux.org/index.php/Bash/Prompt_customization#Embedding_commands