### PR TITLE
Replace echo with echo_out

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -87,7 +87,7 @@ assume-role(){
 
   # load default assume-role profile if available, use "default" otherwise
   if [ "$AWS_PROFILE_ASSUME_ROLE" ]; then
-    echo "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
+    echo_out "Using assume-role default profile: $AWS_PROFILE_ASSUME_ROLE"
     default_profile=${AWS_PROFILE_ASSUME_ROLE}
   else
     default_profile="default"


### PR DESCRIPTION
When you export `AWS_PROFILE_ASSUME_ROLE`, running this script via `eval` returns:

```
$ eval $(assume-role <account> read 123456)                                                                                                                                                                                             
zsh: command not found: Using
```

Replacing `echo` with `echo_out` makes it behave properly.