### PR TITLE
Support for AssumeRoleWithSAML

### DIFF
--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -1,0 +1,8 @@
+---
+operate:
+  budget_org: infra
+  slack_channels:
+    - "#infra-codeflow"
+secure:
+  required_reviews: 1
+  requires_mfa: true

--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -1,8 +1,0 @@
----
-operate:
-  budget_org: infra
-  slack_channels:
-    - "#infra-codeflow"
-secure:
-  required_reviews: 1
-  requires_mfa: true

--- a/README.md
+++ b/README.md
@@ -174,11 +174,20 @@ PROMPT=`echo $PROMPT | rev | sed 's/ / )ofni_tnuocca_swa($ /'| rev`
 For `bash` you could put the following in your `.bash_profile` file:
 
 ```bash
-function aws_account_info {
-  [ "$AWS_ACCOUNT_NAME" ] && [ "$AWS_ACCOUNT_ROLE" ] && echo -n "aws:($AWS_ACCOUNT_NAME:$AWS_ACCOUNT_ROLE) "
+function bash_prompt {
+  PS1="\e[1;31m\W\e[m\$ \e[m"
+
+  NOW=$(date +%s)
+  ROLE_SESSION_TIMEOUT_DELTA=$((NOW - ROLE_SESSION_START))
+
+  if [ "$ROLE_SESSION_TIMEOUT" -gt "$ROLE_SESSION_TIMEOUT_DELTA" ]; then
+    if [ "$AWS_ACCOUNT_NAME" ] && [ "$AWS_ACCOUNT_ROLE" ]; then
+      PS1="(\e[1;34m$AWS_ACCOUNT_ROLE\e[m@\e[0;32m$AWS_ACCOUNT_NAME\e[m) $PS1"
+    fi
+  fi
 }
 
-PROMPT_COMMAND='aws_account_info'
+PROMPT_COMMAND=bash_prompt
 ```
 
 ## Testing

--- a/assume-role
+++ b/assume-role
@@ -41,7 +41,6 @@ assume-role(){
   export-envars
   debug-info
   cleanup
-  set +x
 }
 
 setup() {
@@ -202,7 +201,7 @@ assume-role-with-saml() {
     return 1
   fi
 
-  echo_out "Authenticating with SAML..."
+  echo_out "Gathering SAML credentials..."
   if [ -z "$saml_email" ]; then
     echo_out -n "Email: "
     read -r saml_email
@@ -214,11 +213,11 @@ assume-role-with-saml() {
     echo_out
   fi
 
-  echo_out "Sending Duo Push..."
+  echo_out "Authenticating with SAML provider..."
+  api_body=`eval echo $SAML_IDP_REQUEST_BODY_TEMPLATE`
   # Should be ok to post password as long as service is over SSL
   export saml_assertion_b64=$(curl -s -X POST $SAML_IDP_ASSERTION_URL -H \
-    "Content-Type: application/json" \
-    -d "{\"service\":\"aws\",\"email\":\"$saml_email\",\"password\":\"$saml_password\"}" \
+    "Content-Type: application/json" -d "$api_body" \
     | jq .saml_response -r)
 
   unset saml_password
@@ -380,6 +379,7 @@ cleanup() {
   unset SESSION
   unset SESSION_ARGS
   unset SESSION_TIMEOUT
+  unset api_body
   unset account_name_input
   unset role_input
   unset aws_region_input

--- a/assume-role
+++ b/assume-role
@@ -4,13 +4,16 @@
 # assume-role is a command line tool to help assume roles through a bastion account with MFA.
 # Store your bastion account credentials here ~/.aws/credentials
 #
-# Usage: assume-role [account_name] [role] [mfa_token] [aws-region]
+# Usage: assume-role --saml [account_name] [role] [mfa_token] [aws-region]
+# --saml                use assume-role-with-saml instead
+#
 # account_name          account id or alias
 #                       aliases stored in ~/.aws/accounts as JSON {"alias": account_id}
 #                       [default 'default']
 # role                  the role to assume into the account
 #                       [default 'read']
 # mfa_token             The MFA token for the user
+#                       only valid if --saml flag is not present
 #
 # aws_region            region to assume into default set in ~/.aws/config
 #
@@ -26,6 +29,20 @@ echo_out() {
 }
 
 assume-role(){
+  setup $@
+
+  if [[ $1 == "--saml" ]]; then
+    assume-role-with-saml
+  else
+    assume-role-with-bastion
+  fi
+
+  export-envars
+  debug-info
+  cleanup
+}
+
+setup() {
   #######
   # PRE-CONDITIONS
   #######
@@ -65,15 +82,26 @@ assume-role(){
   export AWS_PROFILE_ASSUME_ROLE
 
   # INPUTS
-  account_name_input=$1
-  role_input=$2
-  mfa_token_input=$3
-  aws_region_input=$4
+  if [[ $1 == "--saml" ]]; then
+    account_name_input=$2
+    role_input=$3
+    aws_region_input=$4
+  else
+    account_name_input=$1
+    role_input=$2
+    mfa_token_input=$3
+    aws_region_input=$4
+  fi
 
   # DEFAULT VARIABLES
   ACCOUNTS_FILE=${ACCOUNTS_FILE:-~/.aws/accounts}
   SESSION_TIMEOUT=43200
   ROLE_SESSION_TIMEOUT=3600
+  SAML_IDP_ASSERTION_URL=${SAML_IDP_ASSERTION_URL:-https://saml-dev.cbhq.net/api/v1/saml/sso}
+
+  if [[ $1 == "--saml" ]] && [ -z $(echo $SAML_IDP_ASSERTION_URL | grep ^https) ]; then
+    echo_out "[WARNING] - Using non-https url ($SAML_IDP_ASSERTION_URL) for SAML authentication. Your credentials may be sent via plaintext."
+  fi
 
   # Force use of ~/.aws/credentials file which contains aws login account
   unset AWS_ACCESS_KEY_ID
@@ -164,7 +192,47 @@ assume-role(){
 
   AWS_REGION="$region"
   AWS_DEFAULT_REGION="$region"
+}
 
+assume-role-with-saml() {
+  if [ $OUTPUT_TO_EVAL ]; then
+    echo_out "assume-role --saml does not support eval. Please source the script and call the assume-role function instead."
+    return 1
+  fi
+
+  echo_out "Authenticating with SAML..."
+  if [ -z "$saml_email" ]; then
+    echo_out -n "Email: "
+    read -r saml_email
+  fi
+
+  if [ -z "$saml_password" ]; then
+    echo_out -n "Password: "
+    read -r -s saml_password
+    echo_out
+  fi
+
+  echo_out "Sending Duo Push..."
+  # Should be ok to post password as long as service is over SSL
+  export saml_assertion_b64=$(curl -s -X POST $SAML_IDP_ASSERTION_URL -H \
+    "Content-Type: application/json" \
+    -d "{\"service\":\"aws\",\"email\":\"$saml_email\",\"password\":\"$saml_password\"}" \
+    | jq .saml_response -r)
+
+  unset saml_password
+
+  NOW=$(date +"%s")
+  ROLE_SESSION_START=$NOW
+
+  ROLE_SESSION_ARGS=(--role-arn arn:aws:iam::${account_id}:role/${role})
+  ROLE_SESSION_ARGS+=(--principal-arn arn:aws:iam::${account_id}:saml-provider/saml-idp)
+  ROLE_SESSION_ARGS+=(--saml-assertion $saml_assertion_b64)
+  ROLE_SESSION_ARGS+=(--duration-seconds "${ROLE_SESSION_TIMEOUT}")
+
+  ROLE_SESSION=$(aws sts assume-role-with-saml "${ROLE_SESSION_ARGS[@]}" || echo "fail")
+}
+
+assume-role-with-bastion() {
   # Activate our session
   NOW=$(date +"%s")
   if [ -z "$AWS_SESSION_START" ]; then
@@ -180,6 +248,7 @@ assume-role(){
     if [ -z "$mfa_token_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
       echo -n "MFA Token: "
       read -r -s mfa_token
+      echo
     else
       mfa_token="$mfa_token_input"
     fi
@@ -234,6 +303,8 @@ assume-role(){
   export AWS_SESSION_TOKEN=$AWS_SESSION_SESSION_TOKEN
   export AWS_SECURITY_TOKEN=$AWS_SESSION_SECURITY_TOKEN
 
+  ROLE_SESSION_START=$NOW
+
   # Now drop into a role using session token's long-lived MFA
   ROLE_SESSION_ARGS=(--role-arn arn:aws:iam::${account_id}:role/${role})
   ROLE_SESSION_ARGS+=(--external-id "${account_id}")
@@ -241,20 +312,23 @@ assume-role(){
   ROLE_SESSION_ARGS+=(--role-session-name "$(date +%s)")
 
   ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
+}
 
+export-envars() {
   if [ "$ROLE_SESSION" = "fail" ]; then
      echo_out "Failed to export session envars."
      # This will force a new session next time assume-role is run
      unset AWS_SESSION_START
   else
-    AWS_ACCESS_KEY_ID=$(echo "$ROLE_SESSION" | jq -r .Credentials.AccessKeyId)
-    AWS_SECRET_ACCESS_KEY=$(echo "$ROLE_SESSION" | jq -r .Credentials.SecretAccessKey)
-    AWS_SESSION_TOKEN=$(echo "$ROLE_SESSION" | jq -r .Credentials.SessionToken)
-    AWS_SECURITY_TOKEN=$AWS_SESSION_TOKEN
-    AWS_ACCOUNT_ID="$account_id"
-    AWS_ACCOUNT_NAME="$account_name"
-    AWS_ACCOUNT_ROLE="$role"
-    GEO_ENV="$account_name" # For GeoEngineer https://github.com/coinbase/geoengineer
+    export AWS_ACCESS_KEY_ID=$(echo "$ROLE_SESSION" | jq -r .Credentials.AccessKeyId)
+    export AWS_SECRET_ACCESS_KEY=$(echo "$ROLE_SESSION" | jq -r .Credentials.SecretAccessKey)
+    export AWS_SESSION_TOKEN=$(echo "$ROLE_SESSION" | jq -r .Credentials.SessionToken)
+    export AWS_SECURITY_TOKEN=$AWS_SESSION_TOKEN
+    export AWS_ACCOUNT_ID="$account_id"
+    export AWS_ACCOUNT_NAME="$account_name"
+    export AWS_ACCOUNT_ROLE="$role"
+    export ROLE_SESSION_START="$ROLE_SESSION_START"
+    export GEO_ENV="$account_name" # For GeoEngineer https://github.com/coinbase/geoengineer
     echo_out "Success! IAM session envars are exported."
   fi
 
@@ -277,11 +351,15 @@ assume-role(){
     echo "export AWS_PROFILE_ASSUME_ROLE=\"$AWS_PROFILE_ASSUME_ROLE\";"
     echo "export AWS_SECURITY_TOKEN=\"$AWS_SESSION_TOKEN\";"
   fi
+}
 
+debug-info() {
   # USED FOR TESTING AND DEBUGGING
   if [ "$DEBUG_ASSUME_ROLE" = "true" ]; then
     echo "AWS_CONFIG_REGION=\"$AWS_CONFIG_REGION\";"
     echo "AWS_USERNAME=\"$AWS_USERNAME\";"
+    echo "AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\";"
+    echo "AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\";"
     echo "MFA_DEVICE_ARGS=\"${MFA_DEVICE_ARGS[*]}\";"
     echo "MFA_DEVICE=\"$MFA_DEVICE\";"
     echo "SESSION_ARGS=\"${SESSION_ARGS[*]}\";"
@@ -292,6 +370,18 @@ assume-role(){
     echo "ROLE_SESSION_TIMEOUT=\"$ROLE_SESSION_TIMEOUT\";"
     echo "AWS_PROFILE_ASSUME_ROLE=\"$AWS_PROFILE_ASSUME_ROLE\";"
   fi
+}
+
+cleanup() {
+  unset ROLE_SESSION
+  unset ROLE_SESSION_ARGS
+  unset SESSION
+  unset SESSION_ARGS
+  unset SESSION_TIMEOUT
+  unset account_name_input
+  unset role_input
+  unset aws_region_input
+  unset mfa_token
 }
 
 # from https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced

--- a/assume-role
+++ b/assume-role
@@ -4,8 +4,7 @@
 # assume-role is a command line tool to help assume roles through a bastion account with MFA.
 # Store your bastion account credentials here ~/.aws/credentials
 #
-# Usage: assume-role --saml [account_name] [role] [mfa_token] [aws-region]
-# --saml                use assume-role-with-saml instead
+# Usage: assume-role [account_name] [role] [mfa_token] [aws-region]
 #
 # account_name          account id or alias
 #                       aliases stored in ~/.aws/accounts as JSON {"alias": account_id}
@@ -13,7 +12,7 @@
 # role                  the role to assume into the account
 #                       [default 'read']
 # mfa_token             The MFA token for the user
-#                       only valid if --saml flag is not present
+#                       only valid if not using SAML for auth
 #
 # aws_region            region to assume into default set in ~/.aws/config
 #
@@ -31,15 +30,18 @@ echo_out() {
 assume-role(){
   setup $@
 
-  if [[ $1 == "--saml" ]]; then
+  if [[ $AWS_ASSUME_ROLE_AUTH_SCHEME == "saml" ]]; then
     assume-role-with-saml
-  else
+  elif [[ $AWS_ASSUME_ROLE_AUTH_SCHEME == "bastion" ]]; then
     assume-role-with-bastion
+  else
+    return 1
   fi
 
   export-envars
   debug-info
   cleanup
+  set +x
 }
 
 setup() {
@@ -82,10 +84,10 @@ setup() {
   export AWS_PROFILE_ASSUME_ROLE
 
   # INPUTS
-  if [[ $1 == "--saml" ]]; then
-    account_name_input=$2
-    role_input=$3
-    aws_region_input=$4
+  if [[ $AWS_ASSUME_ROLE_AUTH_SCHEME == "saml" ]]; then
+    account_name_input=$1
+    role_input=$2
+    aws_region_input=$3
   else
     account_name_input=$1
     role_input=$2
@@ -97,9 +99,9 @@ setup() {
   ACCOUNTS_FILE=${ACCOUNTS_FILE:-~/.aws/accounts}
   SESSION_TIMEOUT=43200
   ROLE_SESSION_TIMEOUT=3600
-  SAML_IDP_ASSERTION_URL=${SAML_IDP_ASSERTION_URL:-https://saml-dev.cbhq.net/api/v1/saml/sso}
+  AWS_ASSUME_ROLE_AUTH_SCHEME=${AWS_ASSUME_ROLE_AUTH_SCHEME:-bastion}
 
-  if [[ $1 == "--saml" ]] && [ -z $(echo $SAML_IDP_ASSERTION_URL | grep ^https) ]; then
+  if [[ $AWS_ASSUME_ROLE_AUTH_SCHEME == "saml" ]] && [ -z $(echo $SAML_IDP_ASSERTION_URL | grep ^https) ]; then
     echo_out "[WARNING] - Using non-https url ($SAML_IDP_ASSERTION_URL) for SAML authentication. Your credentials may be sent via plaintext."
   fi
 
@@ -196,7 +198,7 @@ setup() {
 
 assume-role-with-saml() {
   if [ $OUTPUT_TO_EVAL ]; then
-    echo_out "assume-role --saml does not support eval. Please source the script and call the assume-role function instead."
+    echo_out "assume-role-with-saml does not support eval. Please source the script and call the assume-role function instead."
     return 1
   fi
 


### PR DESCRIPTION
* Allows users to authenticate with their SAML IdP by requesting a signed assertion, and then calling `aws sts assume-role-with-saml` with the signed assertion.

* Document how to setup a SAML provider in AWS for doing AssumeRoleWithSAML

* Use an envar to define the JSON body schema for posting to your SAML provider.

Hopefully it is generic enough to open source. One concern is that I expect the `saml_response` JSON key to be in the response, so that is still some opinion that I am asserting, and I don't like that. Also, I don't really know of any SAML IdP APIs that do what I have mentioned, usually people use an existing SAML provider like Okta, which won't have this setup. 

It is possible that there is an existing [SAML Profile](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) that may support this, I just haven't looked into it enough. If there is a profile that supports this, I may switch the implementation to use that to make this more appropriate for open source.