### PR TITLE
use echo-out everywhere and send output to stderr. 

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -23,7 +23,7 @@ echo_out() {
   if [ -z "$OUTPUT_TO_EVAL" ]; then
     echo "$@"
   else
-    echo "echo \"$*\";"
+    echo \"$*\" >> /dev/stderr
   fi
 }
 
@@ -130,7 +130,7 @@ setup() {
 
   # set account_name
   if [ -z "$account_name_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Account [default]:"
+    echo_out -n "Assume Into Account [default]:"
     read -r account_name
     # default
     account_name=${account_name:-"default"}
@@ -156,7 +156,7 @@ setup() {
 
   # set role
   if [ -z "$role_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Role [read]: "
+    echo_out -n "Assume Into Role [read]: "
     read -r role
     role=${role:-"read"}
   else
@@ -171,7 +171,7 @@ setup() {
   # set region
   AWS_CONFIG_REGION="$(aws configure get region --profile ${default_profile})"
   if [ -z "$aws_region_input" ] && [ -z "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ] && [ -z "$AWS_CONFIG_REGION" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Region [us-east-1]: "
+    echo_out -n "Assume Into Region [us-east-1]: "
     read -r region
     region=${region:-"us-east-1"}
   elif [ ! -z "$aws_region_input" ]; then
@@ -259,7 +259,7 @@ assume-role-with-bastion() {
   if [ "$ABOUT_SESSION_TIMEOUT" -lt "$SESSION_TIMEOUT_DELTA" ]; then
     # We'll need a token to renew session
     if [ -z "$mfa_token_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-      echo -n "MFA Token: "
+      echo_out -n "MFA Token: "
       read -r -s mfa_token
       echo
     else


### PR DESCRIPTION
This PR is the first step to improve multi-shell support, specifically fish as described in https://github.com/coinbase/assume-role/issues/32

With this PR applied, the only output to stdout are limited to the `export` statements. These are easy to transform into the syntax of other shells. Other commands like `echo` are presented to the user. The `read` command works as before and allows interactive prompts even when `assume-role` is called via `eval` or similar techniques (fish source).

Next step would be to ask for the MFA token interactively.
Eventually I would like to include also yubikey suppport (time-based codes).