### PR TITLE
Add option to define AWS_USERNAME manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ However, be aware that for [chained roles](https://docs.aws.amazon.com/IAM/lates
 
 > DurationSeconds exceeds the 1 hour session limit for roles assumed by role chaining.
 
+You can also override the AWS IAM username which is usually fetched from the AWS IAM get-user api. This might not be allowed in some environments though:
+```bash
+$ export AWS_USERNAME=my_username
+```
+
 ## AWS Bastion Account Setup
 
 Here is a simple example of how to set up a **Bastion** AWS account with an id `0987654321098` and a **Production** account with the id `123456789012`.

--- a/assume-role
+++ b/assume-role
@@ -271,10 +271,14 @@ assume-role-with-bastion() {
       return 1
     fi
 
-    # get the username attached to your default creds
-    AWS_USERNAME=$(aws iam get-user --query User.UserName --output text --profile $default_profile)
-
-
+    # check if the AWS_USERNAME has been preset
+    if [ -z "$AWS_USERNAME" ]; then
+      # get the username attached to your default creds
+      AWS_USERNAME=$(aws iam get-user --query User.UserName --output text --profile $default_profile)
+    else
+      echo_out "Using AWS_USERNAME: $AWS_USERNAME"
+    fi
+    
     # get MFA device attached to default creds
     MFA_DEVICE_ARGS=(--user-name "$AWS_USERNAME")
     MFA_DEVICE_ARGS+=(--query 'MFADevices[0].SerialNumber')


### PR DESCRIPTION
I have an environment in which i do not control the bastion account. The policies of the account deny me to call "iam get-user", so i cannot use assume role. I added an option to override AWS_USERNAME via env var. As the rest of assume-role works perfectly, it would be nice to get this added as it also might help others in a similar situation.