### PR TITLE
Add Yubikey (oath)  support

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -341,10 +341,12 @@ export-envars() {
     AWS_ACCESS_KEY_ID=$(echo "$ROLE_SESSION" | jq -r .Credentials.AccessKeyId)
     AWS_SECRET_ACCESS_KEY=$(echo "$ROLE_SESSION" | jq -r .Credentials.SecretAccessKey)
     AWS_SESSION_TOKEN=$(echo "$ROLE_SESSION" | jq -r .Credentials.SessionToken)
+    AWS_SESSION_TOKEN_EXPIRATION=$(echo "$ROLE_SESSION" | jq -r .Credentials.Expiration)
     export AWS_ACCESS_KEY_ID
     export AWS_SECRET_ACCESS_KEY
     export AWS_SESSION_TOKEN
     export AWS_SECURITY_TOKEN=$AWS_SESSION_TOKEN
+    export AWS_SECURITY_TOKEN_EXPIRATION=$AWS_SESSION_TOKEN_EXPIRATION
     export AWS_ACCOUNT_ID="$account_id"
     export AWS_ACCOUNT_NAME="$account_name"
     export AWS_ACCOUNT_ROLE="$role"
@@ -360,6 +362,7 @@ export-envars() {
     echo "export AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\";"
     echo "export AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\";"
     echo "export AWS_SESSION_TOKEN=\"$AWS_SESSION_TOKEN\";"
+    echo "export AWS_SESSION_TOKEN_EXPIRATION=\"$AWS_SESSION_TOKEN_EXPIRATION\";"
     echo "export AWS_ACCOUNT_ID=\"$AWS_ACCOUNT_ID\";"
     echo "export AWS_ACCOUNT_NAME=\"$AWS_ACCOUNT_NAME\";"
     echo "export AWS_ACCOUNT_ROLE=\"$AWS_ACCOUNT_ROLE\";"

--- a/assume-role
+++ b/assume-role
@@ -23,7 +23,7 @@ echo_out() {
   if [ -z "$OUTPUT_TO_EVAL" ]; then
     echo "$@"
   else
-    echo \"$*\" >> /dev/stderr
+    echo "$@" >> /dev/stderr
   fi
 }
 
@@ -257,6 +257,10 @@ assume-role-with-bastion() {
 
   # if session doesn't exist, or is expired
   if [ "$ABOUT_SESSION_TIMEOUT" -lt "$SESSION_TIMEOUT_DELTA" ]; then
+    if [ "x$AWS_ASSUME_ROLE_MFA_YKMAN_OATH_NAME" != "x" ]; then
+      mfa_token_input=$(ykman oath code -s "$AWS_ASSUME_ROLE_MFA_YKMAN_OATH_NAME")
+    fi
+
     # We'll need a token to renew session
     if [ -z "$mfa_token_input" ]; then
       echo_out -n "MFA Token: "

--- a/assume-role
+++ b/assume-role
@@ -23,7 +23,7 @@ echo_out() {
   if [ -z "$OUTPUT_TO_EVAL" ]; then
     echo "$@"
   else
-    echo "echo \"$*\";"
+    echo \"$*\" >> /dev/stderr
   fi
 }
 
@@ -130,7 +130,7 @@ setup() {
 
   # set account_name
   if [ -z "$account_name_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Account [default]:"
+    echo_out -n "Assume Into Account [default]:"
     read -r account_name
     # default
     account_name=${account_name:-"default"}
@@ -156,7 +156,7 @@ setup() {
 
   # set role
   if [ -z "$role_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Role [read]: "
+    echo_out -n "Assume Into Role [read]: "
     read -r role
     role=${role:-"read"}
   else
@@ -171,7 +171,7 @@ setup() {
   # set region
   AWS_CONFIG_REGION="$(aws configure get region --profile ${default_profile})"
   if [ -z "$aws_region_input" ] && [ -z "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ] && [ -z "$AWS_CONFIG_REGION" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-    echo -n "Assume Into Region [us-east-1]: "
+    echo_out -n "Assume Into Region [us-east-1]: "
     read -r region
     region=${region:-"us-east-1"}
   elif [ ! -z "$aws_region_input" ]; then
@@ -259,7 +259,7 @@ assume-role-with-bastion() {
   if [ "$ABOUT_SESSION_TIMEOUT" -lt "$SESSION_TIMEOUT_DELTA" ]; then
     # We'll need a token to renew session
     if [ -z "$mfa_token_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
-      echo -n "MFA Token: "
+      echo_out -n "MFA Token: "
       read -r -s mfa_token
       echo
     else

--- a/assume-role
+++ b/assume-role
@@ -258,7 +258,7 @@ assume-role-with-bastion() {
   # if session doesn't exist, or is expired
   if [ "$ABOUT_SESSION_TIMEOUT" -lt "$SESSION_TIMEOUT_DELTA" ]; then
     # We'll need a token to renew session
-    if [ -z "$mfa_token_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
+    if [ -z "$mfa_token_input" ]; then
       echo_out -n "MFA Token: "
       read -r -s mfa_token
       echo


### PR DESCRIPTION
With this addition you can plug you yubikey into your USB slot and the time-based codes are read automatically.

In order to activate this feature you have to install `ykman`  and set `export AWS_ASSUME_ROLE_MFA_YKMAN_OATH_NAME="Amazon Web Services:me@alias"` in your bashrc.

You can get the list of code names stored on your yubikey via `ykman oath list`.