### PR TITLE
Do not obfuscate MFA input

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -261,7 +261,7 @@ assume-role-with-bastion() {
     # We'll need a token to renew session
     if [ -z "$mfa_token_input" ] && [ -z "$OUTPUT_TO_EVAL" ]; then
       echo -n "MFA Token: "
-      read -r -s mfa_token
+      read -r mfa_token
       echo
     else
       mfa_token="$mfa_token_input"


### PR DESCRIPTION
This is a minor annoyance for me so opening a PR. 

The `-s` flag here obfuscated what the user is inputting which adds a little friction to the `assume-role` process. A hidden field makes sense for passwords but IMO is unnecessary when inputting a disposable MFA code. Most MFA input fields, including the one on the AWS console login page, are plaintext fields. 