### PR TITLE
don't pollute the environment with AWS_* variables if STS fails

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -317,12 +317,6 @@ assume-role-with-bastion() {
     AWS_SESSION_SECURITY_TOKEN=$AWS_SESSION_SESSION_TOKEN
   fi
 
-  # Use the Session in the login account
-  export AWS_ACCESS_KEY_ID=$AWS_SESSION_ACCESS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$AWS_SESSION_SECRET_ACCESS_KEY
-  export AWS_SESSION_TOKEN=$AWS_SESSION_SESSION_TOKEN
-  export AWS_SECURITY_TOKEN=$AWS_SESSION_SECURITY_TOKEN
-
   ROLE_SESSION_START=$NOW
 
   # Now drop into a role using session token's long-lived MFA
@@ -331,7 +325,12 @@ assume-role-with-bastion() {
   ROLE_SESSION_ARGS+=(--duration-seconds "${ROLE_SESSION_TIMEOUT}")
   ROLE_SESSION_ARGS+=(--role-session-name "$(date +%s)")
 
-  ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
+  # Use the Session in the login account
+  ROLE_SESSION=$(AWS_ACCESS_KEY_ID="$AWS_SESSION_ACCESS_KEY_ID" \
+                 AWS_SECRET_ACCESS_KEY="$AWS_SESSION_SECRET_ACCESS_KEY" \
+                 AWS_SESSION_TOKEN="$AWS_SESSION_SESSION_TOKEN" \
+                 AWS_SECURITY_TOKEN="$AWS_SESSION_SECURITY_TOKEN" \
+                 aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
 }
 
 export-envars() {

--- a/assume-role
+++ b/assume-role
@@ -174,16 +174,16 @@ setup() {
     echo -n "Assume Into Region [us-east-1]: "
     read -r region
     region=${region:-"us-east-1"}
-  elif [ ! -z "$aws_region_input" ]; then
+  elif [ -n "$aws_region_input" ]; then
     # if there is a $aws_region_input then set to $aws_region_input
     region="$aws_region_input"
-  elif [ ! -z "$AWS_REGION" ]; then
+  elif [ -n "$AWS_REGION" ]; then
     # if there is a $AWS_REGION then set to $AWS_REGION
     region="$AWS_REGION"
-  elif [ ! -z "$AWS_DEFAULT_REGION" ]; then
+  elif [ -n "$AWS_DEFAULT_REGION" ]; then
     # if there is a $AWS_DEFAULT_REGION then set to $AWS_DEFAULT_REGION
     region="$AWS_DEFAULT_REGION"
-  elif [ ! -z "$AWS_CONFIG_REGION" ]; then
+  elif [ -n "$AWS_CONFIG_REGION" ]; then
     region=$AWS_CONFIG_REGION
   fi
 


### PR DESCRIPTION
These lines https://github.com/coinbase/assume-role/blob/e3faf991f390bc3a07763b33a44ead5f0c9ed6f4/assume-role#L321-L324 always export the AWS_ACCESS_KEY_ID etc variables, even if the subsequent call to STS fails https://github.com/coinbase/assume-role/blob/e3faf991f390bc3a07763b33a44ead5f0c9ed6f4/assume-role#L334

They represent a valid STS session, but the intention is to use the session only for calling AssumeRole, whereas a user who doesn't notice that there are now AWS_* environment variables could be surprised when his STS session gets used subsequently in his shell instead of his long-lived credentials.  When the session expires, that shell will mysteriously not be able to access the AWS API.

Further, if the user's AWS account has other IAM policies that have conditions based on whether the MFA is present, the user might be surprised that those actions are allowed in this shell even though the `assume-role` errored out.

Instead, only pass the session's credentials to the call to `aws sts` and don't export them.