### PR TITLE
Ensure json output for assume-role call

### DIFF
--- a/assume-role
+++ b/assume-role
@@ -243,6 +243,7 @@ assume-role-with-saml() {
   ROLE_SESSION_ARGS+=(--principal-arn arn:aws:iam::"${account_id}":saml-provider/"${SAML_IDP_NAME}")
   ROLE_SESSION_ARGS+=(--saml-assertion "$saml_assertion_b64")
   ROLE_SESSION_ARGS+=(--duration-seconds "${ROLE_SESSION_TIMEOUT}")
+  ROLE_SESSION_ARGS+=(--output json)
 
   ROLE_SESSION=$(aws sts assume-role-with-saml "${ROLE_SESSION_ARGS[@]}" || return 1)
 }
@@ -331,6 +332,7 @@ assume-role-with-bastion() {
   ROLE_SESSION_ARGS+=(--external-id "${account_id}")
   ROLE_SESSION_ARGS+=(--duration-seconds "${ROLE_SESSION_TIMEOUT}")
   ROLE_SESSION_ARGS+=(--role-session-name "$(date +%s)")
+  ROLE_SESSION_ARGS+=(--output json)
 
   ROLE_SESSION=$(aws sts assume-role "${ROLE_SESSION_ARGS[@]}" || echo "fail")
 }


### PR DESCRIPTION
Should explicitly specify the output type for the assume-role/assume-role-with-saml AWS CLI command in case the default output type is set to some other format (e.g. text).

I was working in an env. where `output = text` was specified in `~/.aws/config` and running assume-role I got the following parse errors:

```
$ assume-role dev admin
Using assume-role default profile: XXX
parse error: Invalid numeric literal at line 1, column 16
parse error: Invalid numeric literal at line 1, column 16
parse error: Invalid numeric literal at line 1, column 16
Success! IAM session envars are exported.
```