### PR TITLE
[comments] add explicit comment for sample credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The script will warn you if you are not serving over SSL.
 
 Once you assume-role, you will be prompted for your SAML credentials (username and password).
 
-If you would like to store your credentials on the filesystem for ease of use, you can create a `~/.saml/credentials` file that looks as such:
+If you would like to store your credentials on the filesystem for ease of use, you can create a `~/.saml/credentials` file.
+
+An example of what this looks like is (example syntax; These are *not* real):
 ```
 username = lukeskywalker
 password = hunter2

--- a/config/.saml/credentials
+++ b/config/.saml/credentials
@@ -1,3 +1,6 @@
 ## Saml Credentials
+##
+## Example syntax; These are *not* real.
+##
 username = lukeskywalker
 password = hunter2


### PR DESCRIPTION
## What?

Adds an explicit comment re: credentials being not real.

## Why?

Confusion from various folks that this might be real credentials (which they are not).

## Test Plan

Trivial: Comment only.